### PR TITLE
[rubish/deleted]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,17 @@ rvm:
   - jruby-19mode
   - 2.0.0
   - 2.1.0
+  - 2.2.0
 
 matrix:
   allow_failures:
     - gemfile: gemfiles/AR_edge.gemfile
+  exclude:
+    - gemfile: gemfiles/AR_3.2.gemfile
+      rvm: 2.2.0
+    - gemfile: gemfiles/Rails_3.2.gemfile
+      rvm: 2.2.0
+      
 
 gemfile:
   - gemfiles/AR_3.2.gemfile


### PR DESCRIPTION
exclude ruby 2.2. / AR 3.2 combination from test matrix
fix: https://github.com/inossidabile/protector/pull/61
